### PR TITLE
Fixed scenario of encrypt HOOK active.

### DIFF
--- a/ramroot
+++ b/ramroot
@@ -221,7 +221,7 @@ ramroot_enable() {
     fi
     # add ramroot to initHOOKS:
     if [[ ! "$initHOOKS" =~ ramroot ]]; then
-        if [[ ! "$initHOOKS" =~ encrypt ]]; then
+        if [[ "$initHOOKS" =~ encrypt ]]; then
             printf ":: encrypt HOOK detected ramroot will execute after encrypt\n"
             initHOOKS="${initHOOKS%encrypt*}encrypt ramroot${initHOOKS#*encrypt}"
         else

--- a/ramroot
+++ b/ramroot
@@ -221,7 +221,12 @@ ramroot_enable() {
     fi
     # add ramroot to initHOOKS:
     if [[ ! "$initHOOKS" =~ ramroot ]]; then
-        initHOOKS="${initHOOKS%udev*}udev ramroot${initHOOKS#*udev}"
+        if [[ ! "$initHOOKS" =~ encrypt ]]; then
+            printf ":: encrypt HOOK detected ramroot will execute after encrypt\n"
+            initHOOKS="${initHOOKS%encrypt*}encrypt ramroot${initHOOKS#*udev}"
+        else
+            initHOOKS="${initHOOKS%udev*}udev ramroot${initHOOKS#*udev}"
+        fi
         printf ":: ramroot added to mkinitcpio.conf HOOKS\n"
         mkinitChange='true'
     fi

--- a/ramroot
+++ b/ramroot
@@ -223,7 +223,7 @@ ramroot_enable() {
     if [[ ! "$initHOOKS" =~ ramroot ]]; then
         if [[ ! "$initHOOKS" =~ encrypt ]]; then
             printf ":: encrypt HOOK detected ramroot will execute after encrypt\n"
-            initHOOKS="${initHOOKS%encrypt*}encrypt ramroot${initHOOKS#*udev}"
+            initHOOKS="${initHOOKS%encrypt*}encrypt ramroot${initHOOKS#*encrypt}"
         else
             initHOOKS="${initHOOKS%udev*}udev ramroot${initHOOKS#*udev}"
         fi


### PR DESCRIPTION
When a encrypt HOOK is active it might be root system encryption which needs to decrypt the root *before* ramroot looks for it.

Please review the code as I just copied the syntax I've no idea what I'm editing.

Thanks.