### PR TITLE
Modify ramroot hook to try fastest to slowest compression algorithms

### DIFF
--- a/usr/lib/initcpio/hooks/ramroot
+++ b/usr/lib/initcpio/hooks/ramroot
@@ -109,7 +109,7 @@ run_hook() {
 
     printf '\e[1;34m  -> \e[1;37maval: %dM\n\e[1;34m  -> ' $ram
     printf '\e[1;37mreqd: %dM\n' $((zram+zram_min+ram_min))
-    # WARM: not enough ram
+    # WARN: not enough ram
     if [ $((ram-ram_min-zram-zram_min)) -le 0 ]; then
         printf '\e[1;33m==> SKIPPED: \e[1;37m%s\e[0;37m\n' \
             'ramroot: not enough ram'
@@ -168,12 +168,18 @@ run_hook() {
     fi
     sleep 1
     zram_device="$(zramctl -f -s ${zram}M -a lz4)"
-    # FAIL: error initializing zram device:
+    # ERROR: error initializing with lz4:
     if [ $? -ne 0 ]; then
-        printf '\e[1;31m==> FAILED: \e[1;37m%s\e[0;37m\n' \
-            'error initializing zram device'
-        sleep 2
-        return 1
+        printf '\e[1;33m==> NOTICE: \e[1;37m%s\e[0;37m\n' \
+            'cannot initialize zram device with lz4, trying lzo'
+        zram_device="$(zramctl -f -s ${zram}M -a lzo)"
+        # FAIL: cannot create zram device with preferred algorithms
+        if [ $? -ne 0 ]; then
+            printf '\e[1;31m==> FAILED: \e[1;37m%s\e[0;37m\n' \
+            'cannot initialize zram device'
+            sleep 2
+            return 1
+        fi
     fi
     mkfs.ext4 -q "$zram_device"
     # FAIL: error formatting zram device:

--- a/usr/lib/initcpio/hooks/ramroot
+++ b/usr/lib/initcpio/hooks/ramroot
@@ -167,11 +167,11 @@ run_hook() {
         sleep 1
     fi
     sleep 1
-    zram_device="$(zramctl -f -s ${zram}M -a lzo_rle)"
-    # ERROR: error initializing with lzo_rle:
+    zram_device="$(zramctl -f -s ${zram}M -a lzo-rle)"
+    # ERROR: error initializing with lzo-rle:
     if [ $? -ne 0 ]; then
         printf '\e[1;33m==> NOTICE: \e[1;37m%s\e[0;37m\n' \
-            'cannot initialize with lzo_rle, trying lz4'
+            'cannot initialize with lzo-rle, trying lz4'
         zram_device="$(zramctl -f -s ${zram}M -a lz4)"
          # ERROR: error initializing with lz4:
         if [ $? -ne 0 ]; then

--- a/usr/lib/initcpio/hooks/ramroot
+++ b/usr/lib/initcpio/hooks/ramroot
@@ -167,7 +167,7 @@ run_hook() {
         sleep 1
     fi
     sleep 1
-    zram_device="$(zramctl -f -s ${zram}M -a lzo)"
+    zram_device="$(zramctl -f -s ${zram}M -a lz4)"
     # FAIL: error initializing zram device:
     if [ $? -ne 0 ]; then
         printf '\e[1;31m==> FAILED: \e[1;37m%s\e[0;37m\n' \

--- a/usr/lib/initcpio/hooks/ramroot
+++ b/usr/lib/initcpio/hooks/ramroot
@@ -171,14 +171,20 @@ run_hook() {
     # ERROR: error initializing with lz4:
     if [ $? -ne 0 ]; then
         printf '\e[1;33m==> NOTICE: \e[1;37m%s\e[0;37m\n' \
-            'cannot initialize zram device with lz4, trying lzo'
-        zram_device="$(zramctl -f -s ${zram}M -a lzo)"
-        # FAIL: cannot create zram device with preferred algorithms
+            'cannot initialize with lz4, trying zstd'
+        zram_device="$(zramctl -f -s ${zram}M -a zstd)"
+         # ERROR: error initializing with zstd:
         if [ $? -ne 0 ]; then
-            printf '\e[1;31m==> FAILED: \e[1;37m%s\e[0;37m\n' \
-            'cannot initialize zram device'
-            sleep 2
-            return 1
+            printf '\e[1;33m==> NOTICE: \e[1;37m%s\e[0;37m\n' \
+                'cannot initialize with zstd, trying lzo'
+            zram_device="$(zramctl -f -s ${zram}M -a lzo)"
+            # FAIL: cannot create zram device with preferred algorithms
+            if [ $? -ne 0 ]; then
+                printf '\e[1;31m==> FAILED: \e[1;37m%s\e[0;37m\n' \
+                    'cannot initialize zram device'
+                sleep 2
+                return 1
+            fi
         fi
     fi
     mkfs.ext4 -q "$zram_device"

--- a/usr/lib/initcpio/hooks/ramroot
+++ b/usr/lib/initcpio/hooks/ramroot
@@ -167,23 +167,29 @@ run_hook() {
         sleep 1
     fi
     sleep 1
-    zram_device="$(zramctl -f -s ${zram}M -a lz4)"
-    # ERROR: error initializing with lz4:
+    zram_device="$(zramctl -f -s ${zram}M -a lzo_rle)"
+    # ERROR: error initializing with lzo_rle:
     if [ $? -ne 0 ]; then
         printf '\e[1;33m==> NOTICE: \e[1;37m%s\e[0;37m\n' \
-            'cannot initialize with lz4, trying zstd'
-        zram_device="$(zramctl -f -s ${zram}M -a zstd)"
-         # ERROR: error initializing with zstd:
+            'cannot initialize with lzo_rle, trying lz4'
+        zram_device="$(zramctl -f -s ${zram}M -a lz4)"
+         # ERROR: error initializing with lz4:
         if [ $? -ne 0 ]; then
             printf '\e[1;33m==> NOTICE: \e[1;37m%s\e[0;37m\n' \
-                'cannot initialize with zstd, trying lzo'
-            zram_device="$(zramctl -f -s ${zram}M -a lzo)"
-            # FAIL: cannot create zram device with preferred algorithms
+                'cannot initialize with lz4, trying zstd'
+            zram_device="$(zramctl -f -s ${zram}M -a zstd)"
+            # ERROR: error initializing with zstd:
             if [ $? -ne 0 ]; then
-                printf '\e[1;31m==> FAILED: \e[1;37m%s\e[0;37m\n' \
-                    'cannot initialize zram device'
-                sleep 2
-                return 1
+                printf '\e[1;33m==> NOTICE: \e[1;37m%s\e[0;37m\n' \
+                    'cannot initialize with zstd, trying lzo'
+                zram_device="$(zramctl -f -s ${zram}M -a lzo)"
+                # FAIL: cannot create zram device with preferred algorithms
+                if [ $? -ne 0 ]; then
+                    printf '\e[1;31m==> FAILED: \e[1;37m%s\e[0;37m\n' \
+                        'cannot initialize zram device'
+                    sleep 2
+                    return 1
+                fi
             fi
         fi
     fi


### PR DESCRIPTION
Not sure if this is truly best performing, but seems to work otherwise and fixes the lzo bug in kernel >= 5.7.4.